### PR TITLE
include rails_helper by default

### DIFF
--- a/lib/solidus_cmd/extension.rb
+++ b/lib/solidus_cmd/extension.rb
@@ -29,6 +29,7 @@ module SolidusCmd
       template 'config/locales/en.yml', "#{file_name}/config/locales/en.yml"
       template 'rspec', "#{file_name}/.rspec"
       template 'spec/spec_helper.rb.tt', "#{file_name}/spec/spec_helper.rb"
+      template 'spec/rails_helper.rb.tt', "#{file_name}/spec/rails_helper.rb"
       template 'rubocop.yml', "#{file_name}/.rubocop.yml"
       template 'travis.yml', "#{file_name}/.travis.yml"
     end

--- a/lib/solidus_cmd/templates/extension/spec/rails_helper.rb.tt
+++ b/lib/solidus_cmd/templates/extension/spec/rails_helper.rb.tt
@@ -1,0 +1,1 @@
+require 'spec_helper.rb'


### PR DESCRIPTION
Reason: when we generate new models within the RailsEngine, it would auto-generate spec file, witch requires `rails_helper` by default.

This pull request add that helper (as a place holder) into the extension generate by default.
