### PR TITLE
Remove version lock for solidus_auth_devise

### DIFF
--- a/lib/solidus_cmd/templates/extension/Gemfile
+++ b/lib/solidus_cmd/templates/extension/Gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 gem 'solidus', github: 'solidusio/solidus'
 # Provides basic authentication functionality for testing parts of your engine
-gem 'solidus_auth_devise', '~> 1.0'
+gem 'solidus_auth_devise'
 
 gemspec


### PR DESCRIPTION
This change removes an outdated version lock for `solidus_auth_devise`
in the Gemfile template. The version specified does not work for current
versions of `solidus_core`.