### PR TITLE
Setup the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+rvm:
+  - 2.4.1

--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,4 @@ Bundler::GemHelper.install_tasks
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new
 
-task default: %i(rubocop spec)
+task default: %i(spec)

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,9 @@
-require "bundler"
+require 'bundler'
+require 'rubocop/rake_task'
+require 'rspec/core/rake_task'
+
 Bundler::GemHelper.install_tasks
+RSpec::Core::RakeTask.new(:spec)
+RuboCop::RakeTask.new
+
+task default: %i(rubocop spec)

--- a/solidus_cmd.gemspec
+++ b/solidus_cmd.gemspec
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+
 $:.push File.expand_path("../lib", __FILE__)
 require 'solidus_cmd/version'
 
@@ -20,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rubocop', '0.37.2'
+  s.add_development_dependency 'rubocop', '>= 0.38'
   s.add_development_dependency 'rubocop-rspec', '1.4.0'
   # Temporary hack until https://github.com/wycats/thor/issues/234 is fixed
   s.add_dependency 'thor', '~> 0.14'


### PR DESCRIPTION
This commit adds the rubocop and rspec tasks as default to have a working build for this gem.
Also updates the rubocop version requirement to work with recent rake versions.