### PR TITLE
Add ffaker dependency to template gemspec

### DIFF
--- a/lib/solidus_cmd/templates/extension/extension.gemspec
+++ b/lib/solidus_cmd/templates/extension/extension.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_core', '<%= solidus_version %>'
 
   s.add_development_dependency 'capybara'
+  s.add_development_dependency 'ffaker'
   s.add_development_dependency 'poltergeist'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'sass-rails'


### PR DESCRIPTION
ffaker was removed as a runtime dependency of Solidus.

We have a require for ffaker in the spec_helper. Even if the author of
the new extension does not need to use ffaker and removes that require
statement, Solidus will complain that Solidus factories need the
library.

PR removing ffaker from Solidus:
https://github.com/solidusio/solidus/pull/2163