### PR TITLE
Replace factory_girl with factory_bot

### DIFF
--- a/lib/solidus_cmd/templates/extension/extension.gemspec
+++ b/lib/solidus_cmd/templates/extension/extension.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'database_cleaner'
-  s.add_development_dependency 'factory_girl'
+  s.add_development_dependency 'factory_bot'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'rubocop', '0.37.2'
   s.add_development_dependency 'rubocop-rspec', '1.4.0'

--- a/lib/solidus_cmd/templates/extension/lib/%file_name%/factories.rb.tt
+++ b/lib/solidus_cmd/templates/extension/lib/%file_name%/factories.rb.tt
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   # Define your Spree extensions Factories within this file to enable applications, and other extensions to use and override them.
   #
   # Example adding this to your spec_helper will load these Factories for use:

--- a/lib/solidus_cmd/templates/extension/spec/spec_helper.rb.tt
+++ b/lib/solidus_cmd/templates/extension/spec/spec_helper.rb.tt
@@ -34,7 +34,7 @@ require 'spree/testing_support/url_helpers'
 require '<%= file_name %>/factories'
 
 RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   # Infer an example group's spec type from the file location.
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
`FactoryGirl` has been deprecated in favor of `FactoryBot` so this
change avoids deprecation warnings in newly created extensions.