### PR TITLE
Relax extensions template rubocop dependency

### DIFF
--- a/lib/solidus_cmd/templates/extension/extension.gemspec
+++ b/lib/solidus_cmd/templates/extension/extension.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_bot'
   s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'rubocop', '0.37.2'
-  s.add_development_dependency 'rubocop-rspec', '1.4.0'
+  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop-rspec'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
 end


### PR DESCRIPTION
There's no need to lock rubocop to a specific version, also that
version has a security vulnerability.