### PR TITLE
Redefine github source in Gemfile to use HTTPS

### DIFF
--- a/lib/solidus_cmd/templates/extension/Gemfile
+++ b/lib/solidus_cmd/templates/extension/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem 'solidus', github: 'solidusio/solidus', branch: branch


### PR DESCRIPTION
Using HTTPS instead of GIT protocol will suppress this warning:

The git source `git://github.com/solidusio/solidus.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.

Plus, this is exactly what `rails new app` already does in Gemfile :)