### PR TITLE
Fix gem version in generated gemspec file

### DIFF
--- a/lib/solidus_cmd/extension.rb
+++ b/lib/solidus_cmd/extension.rb
@@ -19,7 +19,7 @@ module SolidusCmd
       directory 'lib', "#{file_name}/lib"
       directory 'bin', "#{file_name}/bin"
 
-      template 'extension.gemspec', "#{file_name}/#{file_name}.gemspec"
+      template 'extension.gemspec.erb', "#{file_name}/#{file_name}.gemspec"
       template 'Gemfile', "#{file_name}/Gemfile"
       template 'gitignore', "#{file_name}/.gitignore"
       template 'gem_release.yml.tt', "#{file_name}/.gem_release.yml"

--- a/lib/solidus_cmd/templates/extension/extension.gemspec.erb
+++ b/lib/solidus_cmd/templates/extension/extension.gemspec.erb
@@ -4,7 +4,7 @@ require '<%= file_name %>/version'
 
 Gem::Specification.new do |s|
   s.name        = '<%= file_name %>'
-  s.version     = '<%= class_name %>::VERSION'
+  s.version     = <%= class_name %>::VERSION
   s.summary     = 'TODO'
   s.description = 'TODO'
   s.license     = 'BSD-3-Clause'


### PR DESCRIPTION
It shouldn't be a string, but a piece of ruby code.

Plus, to avoid problems with linters, I renamed to file `.erb`.