### PR TITLE
Remove check for Solidus 2.5 now it is EOL

### DIFF
--- a/lib/solidus_cmd/templates/extension/Gemfile
+++ b/lib/solidus_cmd/templates/extension/Gemfile
@@ -7,14 +7,7 @@ gem 'solidus', github: 'solidusio/solidus', branch: branch
 # Provides basic authentication functionality for testing parts of your engine
 gem 'solidus_auth_devise'
 
-# This is needed to avoid incompatibilities between this extension and
-# old versions of solidus (< 2.5). This can be reverted when Solidus 2.4
-# reaches EOL. See https://github.com/solidusio/solidus/pull/2835
-if branch < 'v2.5'
-  gem 'factory_bot', '4.10.0'
-else
-  gem 'factory_bot', '> 4.10.0'
-end
+gem 'factory_bot', '> 4.10.0'
 
 if ENV['DB'] == 'mysql'
   gem 'mysql2', '~> 0.4.10'


### PR DESCRIPTION
Seeing factory_bot 4.10.0 causes a rubocop error which means the provided
Rakefile (from template) can't complete in generated projects