### PR TITLE
Add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 
 solidus_cmd is a command line utility for creating extensions for the [Solidus ecommerce platform](https://github.com/solidusio/solidus).
 
+## DEPRECATION NOTICE :warning: :construction:
+
+This extension is deprecated in favor of [Solidus extension dev tools](https://github.com/solidusio-contrib/solidus_extension_dev_tools).
+
 ## Getting started
 
 Install the gem!

--- a/solidus_cmd.gemspec
+++ b/solidus_cmd.gemspec
@@ -12,6 +12,10 @@ Gem::Specification.new do |s|
   s.license     = 'BSD-3-Clause'
   s.summary     = 'Solidus command line utility'
   s.description = 'tools to create new Solidus extensions'
+  s.post_install_message = <<-EOT
+    This extension was deprecated in favor of solidus_extension_dev_tools
+    (https://github.com/solidusio-contrib/solidus_extension_dev_tools)
+  EOT
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Ref: https://github.com/solidusio-contrib/solidus_extension_dev_tools/issues/12

This gem is not used anymore to generate new Solidus extensions since the task is imported into https://github.com/solidusio-contrib/solidus_extension_dev_tools.